### PR TITLE
Use python's built in function for getting string from hex values

### DIFF
--- a/hacktools/nitro.py
+++ b/hacktools/nitro.py
@@ -263,7 +263,7 @@ def readNFTR(file, generateglyphs=False):
             if pamc.type == 0:
                 firstcode = f.readUShort()
                 for i in range(pamc.lastchar - pamc.firstchar + 1):
-                    c = common.codeToChar(pamc.firstchar + i)
+                    c = chr(pamc.firstchar + i)
                     hdwc = nftr.hdwc[firstcode + i]
                     nftr.glyphs[c] = common.FontGlyph(hdwc.start, hdwc.width, hdwc.length, c, pamc.firstchar + i, firstcode + i)
             elif pamc.type == 1:
@@ -271,7 +271,7 @@ def readNFTR(file, generateglyphs=False):
                     charcode = f.readUShort()
                     if charcode == 0xFFFF or charcode >= len(nftr.hdwc):
                         continue
-                    c = common.codeToChar(pamc.firstchar + i)
+                    c = chr(pamc.firstchar + i)
                     hdwc = nftr.hdwc[charcode]
                     nftr.glyphs[c] = common.FontGlyph(hdwc.start, hdwc.width, hdwc.length, c, pamc.firstchar + i, charcode)
             else:

--- a/hacktools/nitro.py
+++ b/hacktools/nitro.py
@@ -259,7 +259,7 @@ def readNFTR(file, generateglyphs=False):
             pamc.lastchar = f.readUShort()
             pamc.type = f.readUInt()
             nextoffset = pamc.nextoffset = f.readUInt()
-            common.logWarning(" ", vars(pamc))
+            common.logDebug(" ", vars(pamc))
             if pamc.type == 0:
                 firstcode = f.readUShort()
                 for i in range(pamc.lastchar - pamc.firstchar + 1):

--- a/hacktools/nitro.py
+++ b/hacktools/nitro.py
@@ -259,7 +259,7 @@ def readNFTR(file, generateglyphs=False):
             pamc.lastchar = f.readUShort()
             pamc.type = f.readUInt()
             nextoffset = pamc.nextoffset = f.readUInt()
-            common.logDebug(" ", vars(pamc))
+            common.logWarning(" ", vars(pamc))
             if pamc.type == 0:
                 firstcode = f.readUShort()
                 for i in range(pamc.lastchar - pamc.firstchar + 1):
@@ -274,6 +274,14 @@ def readNFTR(file, generateglyphs=False):
                     c = chr(pamc.firstchar + i)
                     hdwc = nftr.hdwc[charcode]
                     nftr.glyphs[c] = common.FontGlyph(hdwc.start, hdwc.width, hdwc.length, c, pamc.firstchar + i, charcode)
+            elif pamc.type == 2:
+                groupnum = f.readUShort()
+                for i in range(groupnum - pamc.firstchar):
+                    charcode = f.readUShort()
+                    c = chr(charcode)
+                    tilenum = f.readUShort()
+                    hdwc = nftr.hdwc[tilenum]
+                    nftr.glyphs[c] = common.FontGlyph(hdwc.start, hdwc.width, hdwc.length, c,  charcode, tilenum)
             else:
                 common.logWarning("Unknown section type", pamc.type)
     return nftr


### PR DESCRIPTION
This will partially fix Illidanz/ndstextgen#2 by allowing non-ASCII characters to work (will not fix not being able to specify text-encoding)