### PR TITLE
codeToChar assumed ASCII was 8-bit and used wrong endian fix

### DIFF
--- a/hacktools/common.py
+++ b/hacktools/common.py
@@ -559,7 +559,7 @@ def codeToChar(code, encoding="shift_jis"):
     try:
         if code < 256:
             return struct.pack("B", code).decode("ascii")
-        return struct.pack(">H", code).decode(encoding)
+        return struct.pack("<H", code).decode(encoding)
     except UnicodeDecodeError:
         return ""
 

--- a/hacktools/common.py
+++ b/hacktools/common.py
@@ -533,7 +533,7 @@ def showProgress(iterable):
             return tqdm(iterable=iterable)
     return iterable
 
-
+0
 # Strings
 def toHex(byte, upper=False):
     hexstr = hex(byte)[2:]
@@ -557,7 +557,7 @@ def isAscii(s):
 
 def codeToChar(code, encoding="shift_jis"):
     try:
-        if code < 256:
+        if code < 128:
             return struct.pack("B", code).decode("ascii")
         return struct.pack("<H", code).decode(encoding)
     except UnicodeDecodeError:

--- a/hacktools/common.py
+++ b/hacktools/common.py
@@ -555,11 +555,14 @@ def isAscii(s):
     return True
 
 
-def codeToChar(code, encoding="shift_jis"):
+def codeToChar(code, littleEndian=True, encoding="shift_jis"):
     try:
         if code < 128:
             return struct.pack("B", code).decode("ascii")
-        return struct.pack("<H", code).decode(encoding)
+        if littleEndian == True:
+            return struct.pack("<H", code).decode(encoding)
+        else:
+            return struct.pack(">H", code).decode(encoding)
     except UnicodeDecodeError:
         return ""
 

--- a/hacktools/common.py
+++ b/hacktools/common.py
@@ -533,7 +533,7 @@ def showProgress(iterable):
             return tqdm(iterable=iterable)
     return iterable
 
-0
+
 # Strings
 def toHex(byte, upper=False):
     hexstr = hex(byte)[2:]

--- a/hacktools/nitro.py
+++ b/hacktools/nitro.py
@@ -263,7 +263,7 @@ def readNFTR(file, generateglyphs=False, encoding="shift_jis"):
             if pamc.type == 0:
                 firstcode = f.readUShort()
                 for i in range(pamc.lastchar - pamc.firstchar + 1):
-                    c = common.codeToChar(pamc.firstchar + i, encoding)
+                    c = common.codeToChar(pamc.firstchar + i, True, encoding)
                     hdwc = nftr.hdwc[firstcode + i]
                     nftr.glyphs[c] = common.FontGlyph(hdwc.start, hdwc.width, hdwc.length, c, pamc.firstchar + i, firstcode + i)
             elif pamc.type == 1:
@@ -271,14 +271,14 @@ def readNFTR(file, generateglyphs=False, encoding="shift_jis"):
                     charcode = f.readUShort()
                     if charcode == 0xFFFF or charcode >= len(nftr.hdwc):
                         continue
-                    c = common.codeToChar(pamc.firstchar + i, encoding)
+                    c = common.codeToChar(pamc.firstchar + i, True, encoding)
                     hdwc = nftr.hdwc[charcode]
                     nftr.glyphs[c] = common.FontGlyph(hdwc.start, hdwc.width, hdwc.length, c, pamc.firstchar + i, charcode)
             elif pamc.type == 2:
                 groupnum = f.readUShort()
                 for i in range(groupnum - pamc.firstchar):
                     charcode = f.readUShort()
-                    c = common.codeToChar(charcode, encoding)
+                    c = common.codeToChar(charcode, True, encoding)
                     tilenum = f.readUShort()
                     hdwc = nftr.hdwc[tilenum]
                     nftr.glyphs[c] = common.FontGlyph(hdwc.start, hdwc.width, hdwc.length, c,  charcode, tilenum)

--- a/hacktools/wii.py
+++ b/hacktools/wii.py
@@ -226,14 +226,14 @@ def getFontGlyphs(file):
             if sectiontype == 0:
                 firstcode = f.readUShort()
                 for i in range(lastchar - firstchar + 1):
-                    c = common.codeToChar(firstchar + i)
+                    c = common.codeToChar(firstchar + i, False)
                     glyphs[c] = common.FontGlyph(hdwc[firstcode + i][0], hdwc[firstcode + i][1], hdwc[firstcode + i][2], c, firstchar + i, firstcode + i)
             elif sectiontype == 1:
                 for i in range(lastchar - firstchar + 1):
                     charcode = f.readUShort()
                     if charcode == 0xffff or charcode >= len(hdwc):
                         continue
-                    c = common.codeToChar(firstchar + i)
+                    c = common.codeToChar(firstchar + i, False)
                     glyphs[c] = common.FontGlyph(hdwc[charcode][0], hdwc[charcode][1], hdwc[charcode][2], c, firstchar + i, charcode)
             else:
                 common.logWarning("Unknown section type", sectiontype)


### PR DESCRIPTION
ASCII is actually 7-bit, not 8-bit, meaning that characters 0x80 - 0xFF would not properly be detected before
Additionally, the NDS is little-endian (apologies if this change breaks other programs other than ndstextgen)